### PR TITLE
Add dependencies to the podspec

### DIFF
--- a/Alamofire-SwiftyJSON.podspec
+++ b/Alamofire-SwiftyJSON.podspec
@@ -11,4 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.source   = { :git => "https://github.com/SwiftyJSON/Alamofire-SwiftyJSON.git", :tag => "1.1.0"}
   s.source_files = "Source/*.swift"
+
+  s.dependency 'Alamofire', '~> 1.1'
+  s.dependency 'SwiftyJSON', '~> 2.1'
 end


### PR DESCRIPTION
You should be able to use this library right away without adding more dependencies and without needing to know which versions of Alamofire and SwiftyJSON are required.
