### PR TITLE
Allow parsing even when there was an error

### DIFF
--- a/Source/Alamofire-SwiftyJSON.swift
+++ b/Source/Alamofire-SwiftyJSON.swift
@@ -42,10 +42,10 @@ extension Request {
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
                 
                 var responseJSON: JSON
-                if error != nil || object == nil{
-                    responseJSON = JSON.nullJSON
+                if let object: AnyObject = object {
+                    responseJSON = SwiftyJSON.JSON(object)
                 } else {
-                    responseJSON = SwiftyJSON.JSON(object!)
+                    responseJSON = JSON.nullJSON
                 }
                 
                 dispatch_async(queue ?? dispatch_get_main_queue(), {


### PR DESCRIPTION
If there's a error with the request (e.g. 400 Bad Request, 401 Unauthorised) there still might be valid JSON in the response (e.g. an error message from the API) that has been serialised by `JSONResponseSerializer`.

This code change allows a `JSON` object to be created, instead of using `nullJSON`. 
