### PR TITLE
Provide code example that works with Xcode 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Easy way to use both [Alamofire](https://github.com/Alamofire/Alamofire) and [Sw
 
 ```swift
 Alamofire.request(.GET, "http://httpbin.org/get", parameters: ["foo": "bar"])
-         .responseSwiftyJSON { (request, response, json, error) in
+         .responseSwiftyJSON({ (request, response, json, error) in
                      println(json)
                      println(error)
-                   }
+                  })
 
 ```


### PR DESCRIPTION
Per issue #21, the Xcode 6.3 compiler will throw an "Ambiguous use of 'responseSwiftyJSON'" error using the original code sample provided. Simply adding parentheses around the callback method seems to keep the compiler happy.