### PR TITLE
Updated for Almofire 1.3.0

### DIFF
--- a/Source/Alamofire-SwiftyJSON.swift
+++ b/Source/Alamofire-SwiftyJSON.swift
@@ -37,7 +37,7 @@ extension Request {
     */
     public func responseSwiftyJSON(queue: dispatch_queue_t? = nil, options: NSJSONReadingOptions = .AllowFragments, completionHandler: (NSURLRequest, NSHTTPURLResponse?, JSON, NSError?) -> Void) -> Self {
         
-        return response(queue: queue, serializer: Request.JSONResponseSerializer(options: options), completionHandler: { (request, response, object, error) -> Void in
+        return response(queue: queue, responseSerializer: Request.JSONResponseSerializer(options: options), completionHandler: { (request, response, object, error) -> Void in
             
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
                 


### PR DESCRIPTION
Updated to support the new Alamofire 1.3.0 where the return type changed parameter names from `response` to `responseSerializer`