### PR TITLE
Fixing responseSwiftyJSON because Alamofire returns ErrorType instead of NSError

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'Alamofire', :git => 'https://github.com/SwiftyJSON/Alamofire-SwiftyJSON.git', :branch => 'swift-2.0'
+pod 'Alamofire-SwiftyJSON'
+
 ```
 
 ## Usage

--- a/Source/Alamofire-SwiftyJSON.swift
+++ b/Source/Alamofire-SwiftyJSON.swift
@@ -22,7 +22,7 @@ extension Request {
     
     :returns: The request.
     */
-    public func responseSwiftyJSON(completionHandler: (NSURLRequest, NSHTTPURLResponse?, SwiftyJSON.JSON, NSError?) -> Void) -> Self {
+    public func responseSwiftyJSON(completionHandler: (NSURLRequest, NSHTTPURLResponse?, SwiftyJSON.JSON, ErrorType?) -> Void) -> Self {
         return responseSwiftyJSON(nil, options:NSJSONReadingOptions.AllowFragments, completionHandler:completionHandler)
     }
     
@@ -35,7 +35,7 @@ extension Request {
     
     :returns: The request.
     */
-    public func responseSwiftyJSON(queue: dispatch_queue_t? = nil, options: NSJSONReadingOptions = .AllowFragments, completionHandler: (NSURLRequest, NSHTTPURLResponse?, JSON, NSError?) -> Void) -> Self {
+    public func responseSwiftyJSON(queue: dispatch_queue_t? = nil, options: NSJSONReadingOptions = .AllowFragments, completionHandler: (NSURLRequest, NSHTTPURLResponse?, JSON, ErrorType?) -> Void) -> Self {
         
         return response(queue: queue, responseSerializer: Request.JSONResponseSerializer(options: options), completionHandler: { (request, response, result) -> Void in
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {

--- a/Tests/Alamofire_SwiftyJSONTests.swift
+++ b/Tests/Alamofire_SwiftyJSONTests.swift
@@ -22,7 +22,7 @@ class Alamofire_SwiftyJSONTests: XCTestCase {
             expectation.fulfill()
             XCTAssertNotNil(request, "request should not be nil")
             XCTAssertNotNil(response, "response should not be nil")
-            XCTAssertNil(error, "error should be nil")
+            XCTAssertTrue(error == nil, "result error should be nil")
             XCTAssertEqual(responseJSON["args"], SwiftyJSON.JSON(["foo": "bar"] as NSDictionary), "args should be equal")
         })
         waitForExpectationsWithTimeout(10) { (error) in


### PR DESCRIPTION
-update Alamofire 
-update Alamofire-SwiftyJSON 
-> public func responseSwiftyJSON(completionHandler: (NSURLRequest, NSHTTPURLResponse?, SwiftyJSON.JSON, ErrorType?)