### PR TITLE
update cocoapods package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An extension to make serializing [Alamofire](https://github.com/Alamofire/Alamof
 ## Install
 
 ```ruby
-pod 'Alamofire-SwiftyJSON'
+pod 'AlamofireSwiftyJSON'
 ```
 
 ## Usage


### PR DESCRIPTION
'Alamofire-SwiftyJSON' is deprecated.


I found it: 

```bash
pod search Alamofire-SwiftyJSON
Creating search index for spec repo 'master'.. Done!

-> Alamofire-SwiftyJSON (0.1.1) [DEPRECATED in favor of AlamofireSwiftyJSON]
   Alamofire extension for serialize NSData to SwiftyJSON
   pod 'Alamofire-SwiftyJSON', '~> 0.1.1'
   - Homepage: https://github.com/starboychina/AlamofireSwiftyJSON
   - Source:   https://github.com/starboychina/AlamofireSwiftyJSON.git
   - Versions: 0.1.1 [master repo]
```